### PR TITLE
Fix script path evaluation and subsequent loads

### DIFF
--- a/vaadin-development-mode-detector.html
+++ b/vaadin-development-mode-detector.html
@@ -76,37 +76,67 @@
       window.Vaadin.developmentMode = false;
     }
 
-    const preparePath = function (id, extension) {
-      let path = Polymer.DomModule.import("vaadin-development-mode-probe").assetpath;
-      return path + "../" + id + "/" + id + extension;
+    const getAssetpath = function () {
+      return Polymer.DomModule.import("vaadin-development-mode-probe").assetpath;
+    }
+
+    const prepareHtmlPath = function (id) {
+      let path = getAssetpath();
+      return path + "../" + id + "/" + id + ".html";
+    }
+
+    const prepareJsPath = function (id) {
+      const scope = '@vaadin';
+      let path = getAssetpath();
+      return path.slice(0, path.indexOf(scope) + scope.length) + "/" + id + "/" + id + ".js";
+    }
+
+    const runCallback = function(id, optionalArgument) {
+      if (window.Vaadin && window.Vaadin.developmentModeCallback) {
+        const callback = window.Vaadin.developmentModeCallback[id];
+        if (callback) {
+          callback(optionalArgument);
+        }
+      }
     }
 
     const importAndRun = function(id, optionalArgument) {
-      let path = preparePath(id, ".html");
+      let path = prepareHtmlPath(id);
       return Polymer.importHref(path, function() {
-        if (window.Vaadin && window.Vaadin.developmentModeCallback) {
-          const callback = window.Vaadin.developmentModeCallback[id];
-          if (callback) {
-            callback(optionalArgument);
-          }
-        }
+        runCallback(id, optionalArgument);
       }, function() {}, true);
     }
 
     const loadAndRun = function(id, optionalArgument) {
-      let path = preparePath(id, ".js");
-      let src = document.createElement("script");
-      src.setAttribute("src", path);
-      src.async = true;
-      src.onreadystatechange = src.onload = function() {
-        if (window.Vaadin && window.Vaadin.developmentModeCallback) {
-          const callback = window.Vaadin.developmentModeCallback[id];
-          if (callback) {
-            callback(optionalArgument);
+      let path = prepareJsPath(id);
+      let script = document.body.querySelector("script[src='" + path + "'][async]");
+
+      if (!script) {
+        script = document.createElement("script");
+        script.setAttribute("src", path);
+        script.async = true;
+
+        script.onreadystatechange = script.onload = function() {
+          script.__dynamicImportLoaded = true;
+          runCallback(id, optionalArgument);
+        }
+
+        script.onerror = function() {
+          // In case of an error, remove the script from the document so that it
+          // will be automatically created again the next time
+          if (script.parentNode) {
+            script.parentNode.removeChild(script);
           }
         }
       }
-      document.body.appendChild(src);
+
+      if (script.parentNode == null) {
+        document.body.appendChild(script);
+        // if the script already loaded, dispatch a fake load event
+        // so that listeners are called and get a proper event argument.
+      } else if (script.__dynamicImportLoaded) {
+        script.dispatchEvent(new Event('load'));
+      }
     }
 
     window.Vaadin.runIfDevelopmentMode = function(id, optionalArgument) {


### PR DESCRIPTION
- reimplemented some of the `importHref` logic to fire `load` event on subsequent call
- added the workaround to get the correct path (assuming the same scope)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-development-mode-detector/9)
<!-- Reviewable:end -->
