### PR TITLE
Support module script dependencies

### DIFF
--- a/vaadin-development-mode-detector.html
+++ b/vaadin-development-mode-detector.html
@@ -109,12 +109,12 @@
 
     const loadAndRun = function(id, optionalArgument) {
       let path = prepareJsPath(id);
-      let script = document.body.querySelector("script[src='" + path + "'][async]");
+      let script = document.body.querySelector("script[src='" + path + "'][type='module']");
 
       if (!script) {
         script = document.createElement("script");
         script.setAttribute("src", path);
-        script.async = true;
+        script.type = 'module';
 
         script.onreadystatechange = script.onload = function() {
           script.__dynamicImportLoaded = true;


### PR DESCRIPTION
This is required for <vaadin-license-checker> because it depends
on <vaadin-license-box> component.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-development-mode-detector/12)
<!-- Reviewable:end -->
