### PR TITLE
Prefer Flow development mode over localhost check

### DIFF
--- a/vaadin-development-mode-detector.html
+++ b/vaadin-development-mode-detector.html
@@ -21,12 +21,12 @@
         return true;
       }
 
-      if (!isLocalhost()) {
-        return false;
-      }
-
       if (FlowClients) {
         return !isFlowProductionMode();
+      }
+
+      if (!isLocalhost()) {
+        return false;
       }
 
       return !isMinified();


### PR DESCRIPTION
After 5673bd32877d8aa0799d87af80f3ef5980e075af `Vaadin.developmentMode` is always true for localhost even if flow is running in production mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-development-mode-detector/26)
<!-- Reviewable:end -->
